### PR TITLE
Eatery Updating

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ __pycache__/
 
 # More Python stuff
 .DS_Store
+.vscode/
 env/ 
 .Python
 build/

--- a/src/api/controllers/create_transaction.py
+++ b/src/api/controllers/create_transaction.py
@@ -4,6 +4,7 @@ import pytz
 from api.models import TransactionHistoryStore
 from api.util.constants import vendor_name_to_internal_id
 
+
 class CreateTransactionController:
 
     def __init__(self, data):
@@ -13,7 +14,8 @@ class CreateTransactionController:
         if self._data["TIMESTAMP"] == "Invalid date":
             return 0
         tz = pytz.timezone('America/New_York')
-        recent_datetime = tz.localize(datetime.strptime(self._data["TIMESTAMP"], '%Y-%m-%d %I:%M:%S %p'))
+        recent_datetime = tz.localize(datetime.strptime(
+            self._data["TIMESTAMP"], '%Y-%m-%d %I:%M:%S %p'))
         canonical_date = recent_datetime.date()
         block_end_time = recent_datetime.time()
         if recent_datetime.hour < 4:
@@ -29,13 +31,12 @@ class CreateTransactionController:
                 num_inserted += 1
                 try:
                     TransactionHistoryStore.objects.create(
-                        eatery_id = internal_id, 
-                        canonical_date = canonical_date, 
-                        block_end_time = block_end_time, 
+                        eatery_id=internal_id,
+                        canonical_date=canonical_date,
+                        block_end_time=block_end_time,
                         transaction_count=place["CROWD_COUNT"]
                     )
                 except Exception as e:
                     # print(e)
                     num_inserted -= 1
         return num_inserted
-        

--- a/src/api/controllers/update_eatery.py
+++ b/src/api/controllers/update_eatery.py
@@ -1,46 +1,68 @@
 from django.http import QueryDict
 from api.models import EateryStore
 import base64
-import asyncio
+import requests
+import os
 
 
 class UpdateEateryController:
     def __init__(self, id: int, update_map: QueryDict, image):
-        '''
-        Update_map is a dictionary that maps the fields we want to update to 
+        """
+        Update_map is a dictionary that maps the fields we want to update to
         the values we want to map them to
 
-        Requires: id is a valid id and all keys in update_map are valid columns
-        '''
+        Requires: id is a valid id and all keys in update_map are valid fields
+            in the EateryStore class
+        Raises: Exception when invalid keys are provided
+        """
         self.id = id
         self.update_data = {}
-        allowed_fields = ["name", "menu_summary", "location", "campus_area", "online_order_url", "latitude",
-                          "longitude", "payment_accepts_meal_swipes", "payment_accepts_brbs", "payment_accepts_cash"]
 
         if image is not None:
-            asyncio.run(self.upload_image(image))
+            img_url = self.upload_image(image)
+            self.update_data["image_url"] = img_url
 
         for key, val in update_map.items():
-            if key in allowed_fields:
+            try:
                 self.update_data[key] = val
+            except:
+                raise Exception("Invalid update field(s) provided")
 
-    async def upload_image(self, image):
-        '''
+    def upload_image(self, image):
+        """
         Helper method that asynchronously uploads image bytes to assets repo
         Returns: stored image URL
-        '''
+        Raises: Exception invalid file extension when a non jpg, jpeg, gif, or png is provided
+        """
+
+        valid_extensions = ["jpg", "jpeg", "gif", "png"]
+        extension = (str(image)).split(".")
+        extension = extension[len(extension) - 1]
+
+        if extension not in valid_extensions:
+            raise Exception("Invalid File Extension")
 
         b64_encoded_image = b""
         # Encodes bytes in chunks to handle large image files efficiently
         for chunk in image.chunks():
             b64_encoded_image += base64.b64encode(chunk)
 
-        print(b64_encoded_image)
+        b64_encoded_image = b64_encoded_image.decode("utf-8")
+
+        response = requests.post(
+            "https://upload.cornellappdev.com/upload/",
+            json={
+                "bucket": os.environ["IMAGE_BUCKET"],
+                "image": f"data:image/{extension};base64,{b64_encoded_image}",
+            },
+        )
+
+        return response.json()["data"]
 
     def process(self):
-        '''
-        Selects the DB entry we want to update and updates it using provided data
-        '''
+        """
+        Selects DB entry we want to update and updates it using provided data
+        """
 
         # Uses double-splat to map stored update dict to kwargs
         EateryStore.objects.filter(id=self.id).update(**self.update_data)

--- a/src/api/controllers/update_eatery.py
+++ b/src/api/controllers/update_eatery.py
@@ -1,5 +1,6 @@
 from django.http import QueryDict
 from api.models import EateryStore
+from mimetypes import guess_extension, guess_type
 import base64
 import requests
 import os
@@ -38,6 +39,8 @@ class UpdateEateryController:
         valid_extensions = ["jpg", "jpeg", "gif", "png"]
         extension = (str(image)).split(".")
         extension = extension[len(extension) - 1]
+        if extension == "jpg":
+            extension = "jpeg"
 
         if extension not in valid_extensions:
             raise Exception("Invalid File Extension")
@@ -57,7 +60,10 @@ class UpdateEateryController:
             },
         )
 
-        return response.json()["data"]
+        try:
+            return response.json()["data"]
+        except:
+            raise Exception("Image uploading unsuccessful")
 
     def process(self):
         """

--- a/src/api/controllers/update_eatery.py
+++ b/src/api/controllers/update_eatery.py
@@ -1,0 +1,46 @@
+from django.http import QueryDict
+from api.models import EateryStore
+import base64
+import asyncio
+
+
+class UpdateEateryController:
+    def __init__(self, id: int, update_map: QueryDict, image):
+        '''
+        Update_map is a dictionary that maps the fields we want to update to 
+        the values we want to map them to
+
+        Requires: id is a valid id and all keys in update_map are valid columns
+        '''
+        self.id = id
+        self.update_data = {}
+        allowed_fields = ["name", "menu_summary", "location", "campus_area", "online_order_url", "latitude",
+                          "longitude", "payment_accepts_meal_swipes", "payment_accepts_brbs", "payment_accepts_cash"]
+
+        if image is not None:
+            asyncio.run(self.upload_image(image))
+
+        for key, val in update_map.items():
+            if key in allowed_fields:
+                self.update_data[key] = val
+
+    async def upload_image(self, image):
+        '''
+        Helper method that asynchronously uploads image bytes to assets repo
+        Returns: stored image URL
+        '''
+
+        b64_encoded_image = b""
+        # Encodes bytes in chunks to handle large image files efficiently
+        for chunk in image.chunks():
+            b64_encoded_image += base64.b64encode(chunk)
+
+        print(b64_encoded_image)
+
+    def process(self):
+        '''
+        Selects the DB entry we want to update and updates it using provided data
+        '''
+
+        # Uses double-splat to map stored update dict to kwargs
+        EateryStore.objects.filter(id=self.id).update(**self.update_data)

--- a/src/api/controllers/update_eatery.py
+++ b/src/api/controllers/update_eatery.py
@@ -1,6 +1,5 @@
 from django.http import QueryDict
 from api.models import EateryStore
-from mimetypes import guess_extension, guess_type
 import base64
 import requests
 import os
@@ -13,7 +12,7 @@ class UpdateEateryController:
         the values we want to map them to
 
         Requires: id is a valid id and all keys in update_map are valid fields
-            in the EateryStore class
+            in the EateryStore class (except username/password cannot be provided)
         Raises: Exception when invalid keys are provided
         """
         self.id = id
@@ -23,8 +22,26 @@ class UpdateEateryController:
             img_url = self.upload_image(image)
             self.update_data["image_url"] = img_url
 
+        allowed_fields = [
+            "id",
+            "name",
+            "menu_summary",
+            "image_url",
+            "location",
+            "campus_area",
+            "online_order_url",
+            "latitude",
+            "longitude",
+            "payment_accepts_meal_swipes",
+            "payment_accepts_brbs",
+            "payment_accepts_cash",
+        ]
+
         for key, val in update_map.items():
             try:
+                if key not in allowed_fields:
+                    print("e")
+                    raise Exception
                 self.update_data[key] = val
             except:
                 raise Exception("Invalid update field(s) provided")

--- a/src/api/controllers/update_eatery.py
+++ b/src/api/controllers/update_eatery.py
@@ -26,7 +26,6 @@ class UpdateEateryController:
             "id",
             "name",
             "menu_summary",
-            "image_url",
             "location",
             "campus_area",
             "online_order_url",

--- a/src/api/controllers/update_eatery.py
+++ b/src/api/controllers/update_eatery.py
@@ -12,7 +12,8 @@ class UpdateEateryController:
         the values we want to map them to
 
         Requires: id is a valid id and all keys in update_map are valid fields
-            in the EateryStore class (except username/password cannot be provided)
+            in the EateryStore class (except username/password cannot be provided),
+            as well as an optional image field containing an image file to be uploaded
         Raises: Exception when invalid keys are provided
         """
         self.id = id

--- a/src/api/management/commands/ingest_db_snapshot.py
+++ b/src/api/management/commands/ingest_db_snapshot.py
@@ -4,15 +4,16 @@ from api.util.constants import SnapshotFileName
 import api.serializers as serializers
 import json
 
+
 class Command(BaseCommand):
-    help = 'Overrides current state of the db with a db snapshot. Takes --file argument'
+    help = 'Overrides current state of the db with a db snapshot. Takes --input argument'
 
     def add_arguments(self, parser):
         parser.add_argument('--input', type=str)
 
     # Only writes data if the table has been flushed
     def ingest_data(self, serializer, folder_path: str, file_name: SnapshotFileName):
-        with open(f"{folder_path}/{file_name.value}", "r") as file:     
+        with open(f"{folder_path}/{file_name.value}", "r") as file:
             json_objs = []
             for line in file:
                 if (len(line) > 2):
@@ -23,11 +24,19 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         folder_path = options["input"]
-        self.ingest_data(serializers.EateryStoreSerializer, folder_path, SnapshotFileName.EATERY_STORE)
-        self.ingest_data(serializers.AlertStoreSerializer, folder_path, SnapshotFileName.ALERT_STORE)
-        self.ingest_data(serializers.MenuStoreSerializer, folder_path, SnapshotFileName.MENU_STORE)
-        self.ingest_data(serializers.CategoryStoreSerializer, folder_path, SnapshotFileName.CATEGORY_STORE)
-        self.ingest_data(serializers.ItemStoreSerializer, folder_path, SnapshotFileName.ITEM_STORE)
-        self.ingest_data(serializers.SubItemStoreSerializer, folder_path, SnapshotFileName.SUBITEM_STORE)
-        self.ingest_data(serializers.CategoryItemAssociationSerializer, folder_path, SnapshotFileName.CATEGORY_ITEM_ASSOCIATION)
-        self.ingest_data(serializers.DayOfWeekEventScheduleSerializer, folder_path, SnapshotFileName.DAY_OF_WEEK_EVENT_SCHEDULE)
+        self.ingest_data(serializers.EateryStoreSerializer,
+                         folder_path, SnapshotFileName.EATERY_STORE)
+        self.ingest_data(serializers.AlertStoreSerializer,
+                         folder_path, SnapshotFileName.ALERT_STORE)
+        self.ingest_data(serializers.MenuStoreSerializer,
+                         folder_path, SnapshotFileName.MENU_STORE)
+        self.ingest_data(serializers.CategoryStoreSerializer,
+                         folder_path, SnapshotFileName.CATEGORY_STORE)
+        self.ingest_data(serializers.ItemStoreSerializer,
+                         folder_path, SnapshotFileName.ITEM_STORE)
+        self.ingest_data(serializers.SubItemStoreSerializer,
+                         folder_path, SnapshotFileName.SUBITEM_STORE)
+        self.ingest_data(serializers.CategoryItemAssociationSerializer,
+                         folder_path, SnapshotFileName.CATEGORY_ITEM_ASSOCIATION)
+        self.ingest_data(serializers.DayOfWeekEventScheduleSerializer,
+                         folder_path, SnapshotFileName.DAY_OF_WEEK_EVENT_SCHEDULE)

--- a/src/api/models/TransactionModel.py
+++ b/src/api/models/TransactionModel.py
@@ -2,10 +2,12 @@ from django.db import models
 from api.models.EateryModel import EateryStore
 
 # [transaction_count] transactions at [name] in time range [block_end_time - 5 minutes, block_end_time] on [canonical_date]
+
+
 class TransactionHistoryStore(models.Model):
     class Meta:
         unique_together = ('eatery_id', 'block_end_time', 'canonical_date')
-        indexes = [models.Index(fields = ['canonical_date'])]  
+        indexes = [models.Index(fields=['canonical_date'])]
     eatery = models.ForeignKey(EateryStore, on_delete=models.DO_NOTHING)
     canonical_date = models.DateField()
     block_end_time = models.TimeField()

--- a/src/api/urls.py
+++ b/src/api/urls.py
@@ -1,8 +1,9 @@
 from django.urls import path
 
-from api.views import MainDfgView, ReportView
+from api.views import MainDfgView, UpdateView, ReportView
 
 urlpatterns = [
     path("", MainDfgView.as_view(), name="main"),
+    path("update", UpdateView.as_view(), name="update"),
     path("report", ReportView.as_view(), name="report")
 ]

--- a/src/api/views.py
+++ b/src/api/views.py
@@ -9,6 +9,7 @@ from api.dfg.main import main_dfg
 from api.controllers.create_report import CreateReportController
 from api.controllers.update_eatery import UpdateEateryController
 from api.util.json import verify_json_fields, success_json, error_json, FieldType
+
 # Create your views here.
 
 
@@ -17,12 +18,12 @@ class MainDfgView(APIView):
 
     def get(self, request):
         tzinfo = pytz.timezone("US/Eastern")
-        reload = request.GET.get('reload')
+        reload = request.GET.get("reload")
         result = self.dfg(
             tzinfo=tzinfo,
             reload=reload is not None and reload != "false",
             start=date.today(),
-            end=date.today() + timedelta(days=7)
+            end=date.today() + timedelta(days=7),
         )
         return JsonResponse(result)
 
@@ -30,12 +31,19 @@ class MainDfgView(APIView):
 class ReportView(APIView):
     def post(self, request):
         json_body = json.loads(request.body)
-        if not verify_json_fields(json_body, {"eatery_id": FieldType.INT, "type": FieldType.STRING, "content": FieldType.STRING}):
+        if not verify_json_fields(
+            json_body,
+            {
+                "eatery_id": FieldType.INT,
+                "type": FieldType.STRING,
+                "content": FieldType.STRING,
+            },
+        ):
             return JsonResponse(error_json("Malformed Request"))
         CreateReportController(
             eatery_id=EateryID(json_body["eatery_id"]),
             type=json_body["type"],
-            content=json_body["content"]
+            content=json_body["content"],
         ).process()
         return JsonResponse(success_json("Reported"))
 
@@ -45,13 +53,13 @@ class UpdateView(APIView):
         text_params = request.POST
         try:
             image_param = request.FILES.get("image")
-            print(image_param)
         except:
             image_param = None
-        # Will add JSON verification here
-        UpdateEateryController(
-            text_params.get("id"),
-            text_params,
-            image_param
-        ).process()
-        return JsonResponse(success_json("Updated"))
+
+        try:
+            UpdateEateryController(
+                text_params.get("id"), text_params, image_param
+            ).process()
+            return JsonResponse(success_json("Updated"))
+        except Exception as e:
+            return JsonResponse(error_json(str(e)))

--- a/src/api/views.py
+++ b/src/api/views.py
@@ -7,11 +7,14 @@ import json
 from api.datatype.Eatery import EateryID
 from api.dfg.main import main_dfg
 from api.controllers.create_report import CreateReportController
+from api.controllers.update_eatery import UpdateEateryController
 from api.util.json import verify_json_fields, success_json, error_json, FieldType
 # Create your views here.
 
+
 class MainDfgView(APIView):
     dfg = main_dfg
+
     def get(self, request):
         tzinfo = pytz.timezone("US/Eastern")
         reload = request.GET.get('reload')
@@ -22,6 +25,7 @@ class MainDfgView(APIView):
             end=date.today() + timedelta(days=7)
         )
         return JsonResponse(result)
+
 
 class ReportView(APIView):
     def post(self, request):
@@ -34,3 +38,20 @@ class ReportView(APIView):
             content=json_body["content"]
         ).process()
         return JsonResponse(success_json("Reported"))
+
+
+class UpdateView(APIView):
+    def post(self, request):
+        text_params = request.POST
+        try:
+            image_param = request.FILES.get("image")
+            print(image_param)
+        except:
+            image_param = None
+        # Will add JSON verification here
+        UpdateEateryController(
+            text_params.get("id"),
+            text_params,
+            image_param
+        ).process()
+        return JsonResponse(success_json("Updated"))

--- a/src/manage.py
+++ b/src/manage.py
@@ -6,7 +6,8 @@ import sys
 
 def main():
     """Run administrative tasks."""
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "eatery_blue_backend.settings")
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE",
+                          "eatery_blue_backend.settings")
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,3 @@
+source env/bin/activate
+source .env
+python3 src/manage.py runserver 0.0.0.0:8000


### PR DESCRIPTION
Implemented eatery updating endpoint at /update (POST request). Takes form data, and all provided fields must only be fields that we intentionally expose, namely:
            "id",
            "name",
            "menu_summary",
            "location",
            "campus_area",
            "online_order_url",
            "latitude",
            "longitude",
            "payment_accepts_meal_swipes",
            "payment_accepts_brbs",
            "payment_accepts_cash",

The client can also optionally provide an "image" field, which will contain the image file to be uploaded

Here is a sample postman request:
<img width="1108" alt="Screen Shot 2022-03-06 at 2 59 56 PM" src="https://user-images.githubusercontent.com/22649594/156939993-2cfdb90c-de74-432c-8fb8-0c0091b31d73.png">

Here's an example of a request that wouldn't go through:
<img width="1104" alt="Screen Shot 2022-03-06 at 3 03 44 PM" src="https://user-images.githubusercontent.com/22649594/156940144-2b2ab934-a9be-42db-ac36-1be8b9fbaf09.png">

