### PR TITLE
Raised new exception for bad id

### DIFF
--- a/src/api/controllers/update_eatery.py
+++ b/src/api/controllers/update_eatery.py
@@ -1,4 +1,5 @@
 from django.http import QueryDict
+from api.datatype.Eatery import EateryID
 from api.models import EateryStore
 import base64
 import requests
@@ -6,7 +7,7 @@ import os
 
 
 class UpdateEateryController:
-    def __init__(self, id: int, update_map: QueryDict, image):
+    def __init__(self, id: EateryID, update_map: QueryDict, image):
         """
         Update_map is a dictionary that maps the fields we want to update to
         the values we want to map them to
@@ -85,8 +86,5 @@ class UpdateEateryController:
         """
         Selects DB entry we want to update and updates it using provided data
         """
-
-        supplied_eatery = EateryStore.objects.filter(id=self.id)
-        if list(supplied_eatery) == []:
-            raise Exception("Invalid eatery ID supplied")
-        supplied_eatery.update(**self.update_data)
+        # use double-splat to convert dict to kwargs
+        EateryStore.objects.filter(id=self.id.value).update(**self.update_data)

--- a/src/api/controllers/update_eatery.py
+++ b/src/api/controllers/update_eatery.py
@@ -40,7 +40,6 @@ class UpdateEateryController:
         for key, val in update_map.items():
             try:
                 if key not in allowed_fields:
-                    print("e")
                     raise Exception
                 self.update_data[key] = val
             except:
@@ -87,5 +86,7 @@ class UpdateEateryController:
         Selects DB entry we want to update and updates it using provided data
         """
 
-        # Uses double-splat to map stored update dict to kwargs
-        EateryStore.objects.filter(id=self.id).update(**self.update_data)
+        supplied_eatery = EateryStore.objects.filter(id=self.id)
+        if list(supplied_eatery) == []:
+            raise Exception("Invalid eatery ID supplied")
+        supplied_eatery.update(**self.update_data)

--- a/src/api/views.py
+++ b/src/api/views.py
@@ -57,9 +57,12 @@ class UpdateView(APIView):
             image_param = None
 
         try:
-            UpdateEateryController(
-                text_params.get("id"), text_params, image_param
-            ).process()
+            id = int(text_params.get("id"))
+        except:
+            return JsonResponse(error_json("ID must be castable to an int"))
+
+        try:
+            UpdateEateryController(EateryID(id), text_params, image_param).process()
             return JsonResponse(success_json("Updated"))
         except Exception as e:
             return JsonResponse(error_json(str(e)))


### PR DESCRIPTION
Fixed update endpoint so when the user supplies an invalid id it'll raise a more specific error.

When non-int is supplied:
<img width="1107" alt="Screen Shot 2022-03-06 at 7 54 28 PM" src="https://user-images.githubusercontent.com/22649594/156950536-f0458622-95ad-47d3-885a-98a69b987bac.png">

When invalid int is supplied:
<img width="1104" alt="Screen Shot 2022-03-06 at 7 54 45 PM" src="https://user-images.githubusercontent.com/22649594/156950551-a09afaa6-4b60-40a8-89dc-763c1f31b2f7.png">

When valid id is supplied
<img width="1108" alt="Screen Shot 2022-03-06 at 7 55 01 PM" src="https://user-images.githubusercontent.com/22649594/156950567-40b93325-8921-46a7-95a1-fb97547c13a6.png">
:

