### PR TITLE
Change handling of local env in settings.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Security
 .env
 eatery-dev.pem
+.envrc
 
 # Hardcoded stuff
 db_snapshots/

--- a/src/eatery_blue_backend/settings.py
+++ b/src/eatery_blue_backend/settings.py
@@ -78,14 +78,14 @@ WSGI_APPLICATION = "eatery_blue_backend.wsgi.application"
 
 IS_LOCAL = os.getenv("LOCAL")
 
-if IS_LOCAL:
+if IS_LOCAL == "True":
     DATABASES = {
         "default": {
             "ENGINE": "django.db.backends.sqlite3",
             "NAME": BASE_DIR / "db.sqlite3",
         }
     }
-else:
+elif IS_LOCAL == "False":
     DATABASES = {
         "default": {
             "ENGINE": "django.db.backends.postgresql_psycopg2",


### PR DESCRIPTION
Bug would arise if the local environment variable equals False - if False (ie: we wanted to run the production database) the local database would run instead, because local env is a string and code checked for its existence, not whether it is true/false.