### PR TITLE
Add .github folder (PR Template and CODEOWNERS)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*	@Archit404Error @connorreinhold @chalo2000 @markim21

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,48 @@
+<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->
+
+<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->
+
+
+## Overview
+
+<!-- Summarize your changes here. -->
+
+
+
+## Changes Made
+
+<!-- Include details of what your changes actually are and how it is intended to work. -->
+
+
+
+## Test Coverage
+
+<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->
+
+
+
+## Next Steps (delete if not applicable)
+
+<!-- If this is part of a multi-PR change, please describe what changes you plan on addressing in future PRs. -->
+
+
+
+## Related PRs or Issues (delete if not applicable)
+
+<!-- List related PRs against other branches/repositories. -->
+
+
+
+## Screenshots (delete if not applicable)
+
+<!-- This could include of screenshots of the new feature / proof that the changes work. -->
+
+<details>
+
+  <summary>Screen Shot Name</summary>
+
+
+  <!-- Insert file link here. Newlines above and below your link are necessary for this to work. -->
+  
+
+</details>


### PR DESCRIPTION
## Overview
Added a .github folder that will enforce the PR template Gonzalo suggested and also created a CODEOWNERS file so I, Connor, Gonzalo, and Marya are auto-requested as reviewers on every PR that's created (if one of us makes a PR then we won't be self-requested)

## Changes Made
Added .github/ and 2 new files



## Test Coverage
No real testing required