### PR TITLE
Implement simpler eatery route

### DIFF
--- a/src/eatery/serializers.py
+++ b/src/eatery/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 from eatery.models import Eatery
-from event.serializers import EventSerializer
+from event.serializers import EventSerializer, EventSerializerSimple
 
 
 class EaterySerializer(serializers.ModelSerializer):
@@ -22,6 +22,16 @@ class EaterySerializer(serializers.ModelSerializer):
     def create(self, validated_data):
         eatery, _ = Eatery.objects.get_or_create(**validated_data)
         return eatery
+
+    class Meta:
+        model = Eatery
+        fields = ['id', 'name', 'menu_summary', 'image_url', 'location', 'campus_area', 'online_order_url', 'latitude', 'longitude', 'payment_accepts_meal_swipes', 'payment_accepts_brbs', 'payment_accepts_cash', 'events']
+
+
+class EaterySerializerSimple(serializers.ModelSerializer):
+    menu_summary = serializers.CharField(allow_null=True,default="Cornell Eatery")
+    image_url = serializers.URLField(allow_null=True,default="https://images-prod.healthline.com/hlcmsresource/images/AN_images/health-benefits-of-apples-1296x728-feature.jpg")
+    events = EventSerializerSimple(many=True, read_only=True)
 
     class Meta:
         model = Eatery

--- a/src/eatery/urls.py
+++ b/src/eatery/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
-from eatery.views import EateryViewSet
+from eatery.views import EateryViewSet, EateryViewSetSimple
 
 eateries_list = EateryViewSet.as_view({
     'get':'list',
@@ -16,4 +16,5 @@ eatery_list = EateryViewSet.as_view({
 urlpatterns = [
     path("", eateries_list, name='eateries-list'),
     path("<int:pk>/", eatery_list, name='eatery-list'),
+    path("simple/", EateryViewSetSimple.as_view({'get':'list'}), name='eateries-simple'),
 ]

--- a/src/eatery/views.py
+++ b/src/eatery/views.py
@@ -1,4 +1,4 @@
-from eatery.serializers import EaterySerializer
+from eatery.serializers import EaterySerializer, EaterySerializerSimple
 from eatery.util.json import FieldType, error_json, success_json, verify_json_fields
 from django.http import JsonResponse
 from django.shortcuts import get_object_or_404
@@ -90,3 +90,10 @@ class GetEateries(APIView):
             return JsonResponse(error_json("eateries is empty"))
 
         return JsonResponse(success_json(eateries.data))
+
+class EateryViewSetSimple(viewsets.ModelViewSet):
+    """
+    View all eateries with less information
+    """
+    queryset = Eatery.objects.all()
+    serializer_class = EaterySerializerSimple

--- a/src/event/serializers.py
+++ b/src/event/serializers.py
@@ -20,3 +20,8 @@ class EventSerializer(serializers.ModelSerializer):
     class Meta:
         model = Event
         fields = ["id", "eatery", "event_description", "start", "end", "menu"]
+
+class EventSerializerSimple(serializers.ModelSerializer):
+    class Meta:
+        model = Event
+        fields = ["id", "eatery", "event_description", "start", "end"]


### PR DESCRIPTION
## Overview

Create new route that returns less eatery information to decrease load time when first opening the app



## Changes Made

- Implemented new endpoint
- Created two new serializers to decrease the amount of information being sent


## Test Coverage

Tested locally with django rest framework site