### PR TITLE
Remove RPCC and Carol's Cafe

### DIFF
--- a/src/cdn_parser/controllers/populate_models.py
+++ b/src/cdn_parser/controllers/populate_models.py
@@ -2,6 +2,7 @@ import requests
 from eatery.util.constants import CORNELL_DINING_URL, dining_id_to_internal_id
 from django.core import management
 from event.models import Event
+from eatery.models import Eatery
 from eatery.controllers.populate_eatery import PopulateEateryController
 from event.controllers.populate_event import PopulateEventController
 from item.controllers.populate_item import PopulateItemController
@@ -51,8 +52,14 @@ class CornellDiningNowController():
         json_eateries = self.get_json()
         
         Event.truncate()
+        Eatery.truncate()
+
+        print(Eatery.objects.filter(id=16))
+
         print("Populating eateries")
         PopulateEateryController().process(json_eateries)
+
+        print(Eatery.objects.filter(id=16))
 
         print("Populating events")
         events_dict = PopulateEventController().process(json_eateries)    

--- a/src/cdn_parser/controllers/populate_models.py
+++ b/src/cdn_parser/controllers/populate_models.py
@@ -54,12 +54,8 @@ class CornellDiningNowController():
         Event.truncate()
         Eatery.truncate()
 
-        print(Eatery.objects.filter(id=16))
-
         print("Populating eateries")
         PopulateEateryController().process(json_eateries)
-
-        print(Eatery.objects.filter(id=16))
 
         print("Populating events")
         events_dict = PopulateEventController().process(json_eateries)    

--- a/src/eatery/models.py
+++ b/src/eatery/models.py
@@ -24,4 +24,9 @@ class Eatery(models.Model):
     payment_accepts_meal_swipes = models.BooleanField(null=True, blank=True)
     payment_accepts_brbs = models.BooleanField(null=True, blank=True)
     payment_accepts_cash = models.BooleanField(null=True, blank=True)
+    
 
+    @classmethod
+    def truncate(cls):
+        with connection.cursor() as cursor:
+            cursor.execute('TRUNCATE TABLE {} CASCADE'.format(cls._meta.db_table))

--- a/src/eatery/util/eatery_store.txt
+++ b/src/eatery/util/eatery_store.txt
@@ -7,7 +7,6 @@
 {"id": 6, "menu_summary": "Sandwiches, salads, hay", "image_url": "https://raw.githubusercontent.com/cuappdev/assets/master/eatery/eatery-images/Big-Red-Barn.jpg"}
 {"id": 7, "menu_summary": "Bagels, bagels, bagels", "image_url": "https://raw.githubusercontent.com/cuappdev/assets/master/eatery/eatery-images/Bug-Stop-Bagels.jpg"}
 {"id": 8, "menu_summary": "Sandwiches, salads, drinks", "image_url": "https://raw.githubusercontent.com/cuappdev/assets/master/eatery/eatery-images/Cafe-Jennie.jpg"}
-{"id": 9, "name": "Carol's Caf\u00e9", "menu_summary": "Carols, wine, christmas", "image_url": "https://raw.githubusercontent.com/cuappdev/assets/master/eatery/eatery-images/Carols-Cafe.jpg", "location": "Balch Hall", "campus_area": "North", "latitude": 42.4533011, "longitude": -76.4791678, "payment_accepts_meal_swipes": false, "payment_accepts_brbs": false, "payment_accepts_cash": false, "online_order_url": null}
 {"id": 10, "menu_summary": "A west dining classic", "image_url": "https://raw.githubusercontent.com/cuappdev/assets/master/eatery/eatery-images/Cook-House-Dining.jpg"}
 {"id": 11, "menu_summary": "Ice cream and more ice cream", "image_url": "https://raw.githubusercontent.com/cuappdev/assets/master/eatery/eatery-images/Cornell-Dairy-Bar.jpg"}
 {"id": 12, "menu_summary": "Smoothies, quesadillas, snacks", "image_url": "https://raw.githubusercontent.com/cuappdev/assets/master/eatery/eatery-images/Crossings-Cafe.jpg"}
@@ -26,7 +25,6 @@
 {"id": 25, "menu_summary": "Freshly remodeled dining hall", "image_url": "https://raw.githubusercontent.com/cuappdev/assets/master/eatery/eatery-images/North-Star.jpg"}
 {"id": 26, "menu_summary": "The only central campus dining hall", "image_url": "https://raw.githubusercontent.com/cuappdev/assets/master/eatery/eatery-images/Okenshields.jpg"}
 {"id": 27, "menu_summary": "Gluten free dining hall", "image_url": "https://raw.githubusercontent.com/cuappdev/assets/master/eatery/eatery-images/Risley-Dining.jpg"}
-{"id": 28, "menu_summary": "Sushi Fridays, freshly made pho", "image_url": "https://raw.githubusercontent.com/cuappdev/assets/master/eatery/eatery-images/RPCC-Marketplace.jpg"}
 {"id": 29, "menu_summary": "A west dining classic", "image_url": "https://raw.githubusercontent.com/cuappdev/assets/master/eatery/eatery-images/Rose-House-Dining.jpg"}
 {"id": 30, "menu_summary": "Coffee, tea, snacks", "image_url": "https://raw.githubusercontent.com/cuappdev/assets/master/eatery/eatery-images/Rustys.jpg"}
 {"id": 31, "menu_summary": "Soups, salads, snacks", "image_url": "https://raw.githubusercontent.com/cuappdev/assets/master/eatery/eatery-images/StraightMarket.jpg"}


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Overview

Removed the third floor RPCC dining hall and Carol's Cafe. These eateries are no longer in service and are not on the cornell dining website.

## Changes Made

Removed the hard coded eatery information from src/eatery/util/eatery_store.txt. Added a truncate method to src/eatery/models.py and implemented that method in src/cdn_parser/controllers/populate_models.py in order to ensure the eateries get removed from the database.

## Test Coverage

Ran the new code in a virtual environment and compared the local endpoint to the currently running server endpoint to make sure the information being given to frontend is the same other than the two removed eateries.
