### PR TITLE
Resolve empty menus issue for cafes

### DIFF
--- a/src/category/controllers/populate_category.py
+++ b/src/category/controllers/populate_category.py
@@ -76,9 +76,9 @@ class PopulateCategoryController:
             else:
                 continue
 
-            is_cafe = "Cafe" in {
-                eatery_type["descr"] for eatery_type in json_eatery["eateryTypes"]
-            }
+            desired_descriptions = {"Cafe", "Cart", "Coffee Shop", "Food Court"}
+            eatery_descriptions = {eatery_type["descr"] for eatery_type in json_eatery["eateryTypes"]}
+            is_cafe = bool(desired_descriptions.intersection(eatery_descriptions))
 
             """
             For every event in an eatery --> for every menu in an eatery --> get categories

--- a/src/item/controllers/populate_item.py
+++ b/src/item/controllers/populate_item.py
@@ -54,9 +54,9 @@ class PopulateItemController():
             iter = list(eatery_menus.keys())
             i = 0
 
-            is_cafe = "Cafe" in {
-                eatery_type["descr"] for eatery_type in json_eatery["eateryTypes"]
-            }  
+            desired_descriptions = {"Cafe", "Cart", "Coffee Shop", "Food Court"}
+            eatery_descriptions = {eatery_type["descr"] for eatery_type in json_eatery["eateryTypes"]}
+            is_cafe = bool(desired_descriptions.intersection(eatery_descriptions))
 
             json_dates = json_eatery["operatingHours"]
             for json_date in json_dates: 


### PR DESCRIPTION
## Overview

Changed the is_cafe boolean to evaluate to true for cafes, carts, coffee shops, and food courts to fix the fact that the menus for Franny's, Rusty's, Jansen's, and Trillium were empty.

## Changes Made

Changed the implementation of is_cafe to check for all of the above descriptions instead of just cafe.

## Test Coverage

To test this, I made the changes and ran them on my own computer. Then, I checked whether the menus were being filled in correctly.

## Related PRs or Issues (delete if not applicable)

Resolved github issue #65 
