### PR TITLE
Add back event ids for by day endpoint

### DIFF
--- a/src/eatery/views.py
+++ b/src/eatery/views.py
@@ -23,12 +23,12 @@ class EateryViewSet(viewsets.ModelViewSet):
 
     def retrieve(self, request, *args, **kwargs):
         instance = self.get_object()
-        serializer = EateryReadSerializer(instance)
+        serializer = EaterySerializer(instance)
         return Response(serializer.data)
     
     def list(self, request, *args, **kwargs):
         queryset = self.filter_queryset(self.get_queryset())
-        serializer = EateryReadSerializer(queryset, many=True)
+        serializer = EaterySerializer(queryset, many=True)
         return Response(serializer.data)
 
 

--- a/src/event/serializers.py
+++ b/src/event/serializers.py
@@ -22,6 +22,7 @@ class EventSerializer(serializers.ModelSerializer):
         fields = ["id", "eatery", "event_description", "start", "end", "menu"]
 
 class EventReadSerializer(serializers.ModelSerializer):
+    id = serializers.IntegerField(required=False, read_only=True)
     event_description = serializers.CharField(allow_null=True, allow_blank=True, default=None)
     start = serializers.IntegerField()
     end = serializers.IntegerField()
@@ -29,7 +30,7 @@ class EventReadSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Event
-        fields = ["event_description", "start", "end", "menu"]
+        fields = ["id", "event_description", "start", "end", "menu"]
 
 class EventSerializerSimple(serializers.ModelSerializer):
     class Meta:


### PR DESCRIPTION
## Overview

Add back event ids necessary to frontend for by day endpoint

## Changes Made

Added "id" field to EventReadSerializer, which is used in EaterySerializerByDay.

## Test Coverage

Tested locally
