### PR TITLE
Fixed upcoming menus timezone issue

### DIFF
--- a/src/eatery/serializers.py
+++ b/src/eatery/serializers.py
@@ -2,6 +2,7 @@ from rest_framework import serializers
 from eatery.models import Eatery
 from event.models import Event
 from event.serializers import EventSerializer, EventSerializerSimple, EventReadSerializer
+from django.utils import timezone
 from datetime import date, timedelta
 from time import mktime
 
@@ -65,11 +66,11 @@ class EaterySerializerByDay(serializers.ModelSerializer):
 
     def get_events(self, obj):
         day = self.context.get("day")
-        today = date.today()
+        today = timezone.now().date()
         today = today + timedelta(days=day)
         end_today = today + timedelta(days=1)
-        today_unix = mktime(today.timetuple()) + 18000
-        end_today_unix = mktime(end_today.timetuple()) + 18000
+        today_unix = mktime(today.timetuple())
+        end_today_unix = mktime(end_today.timetuple())
         events = Event.objects.filter(eatery=obj.id, start__gte=today_unix, start__lte=end_today_unix)
         serializer = EventReadSerializer(instance=events, many=True)
         return serializer.data


### PR DESCRIPTION
## Overview

Fixed upcoming menus timezone issue

## Changes Made

Time is now defined by the django.utils function timezone.now() instead of datetime.date.today() for the by day endpoint. Also removed the 18000 second adjustment.

## Test Coverage

Tested locally and will be further tested every hour after the change is pushed to dev.
