### PR TITLE
Fix timezone issue again

### DIFF
--- a/src/eatery/serializers.py
+++ b/src/eatery/serializers.py
@@ -66,12 +66,9 @@ class EaterySerializerByDay(serializers.ModelSerializer):
 
     def get_events(self, obj):
         day = self.context.get("day")
-        today = timezone.now().date()
-        today = today + timedelta(days=day)
-        end_today = today + timedelta(days=1)
-        today_unix = mktime(today.timetuple())
-        end_today_unix = mktime(end_today.timetuple())
-        events = Event.objects.filter(eatery=obj.id, start__gte=today_unix, start__lte=end_today_unix)
+        today = (timezone.now() - timedelta(hours=5)).date() + timedelta(days=day)
+        today_unix = mktime(today.timetuple()) + 18000
+        events = Event.objects.filter(eatery=obj.id, start__gte=today_unix, start__lte=today_unix + 86400)
         serializer = EventReadSerializer(instance=events, many=True)
         return serializer.data
 

--- a/src/eatery/serializers.py
+++ b/src/eatery/serializers.py
@@ -67,8 +67,8 @@ class EaterySerializerByDay(serializers.ModelSerializer):
     def get_events(self, obj):
         day = self.context.get("day")
         today = (timezone.now() - timedelta(hours=5)).date() + timedelta(days=day)
-        today_unix = mktime(today.timetuple()) + 18000
-        events = Event.objects.filter(eatery=obj.id, start__gte=today_unix, start__lte=today_unix + 86400)
+        today_unix = mktime(today.timetuple()) + timedelta(hours=5).seconds
+        events = Event.objects.filter(eatery=obj.id, start__gte=today_unix, start__lte=today_unix + timedelta(days=1).seconds)
         serializer = EventReadSerializer(instance=events, many=True)
         return serializer.data
 


### PR DESCRIPTION
## Overview

Fixed by day endpoint timezone issue.

## Changes Made

Since time is given in UTC, 5 hours must be subtracted before getting the current date. Then, 18000 seconds must be added to the epoch time because the function time.mktime(today.timetuple()) returns epoch time in UTC and we want the final range to be midnight EST today to midnight EST the next day.

## Test Coverage

Tested locally and will continue to be tested on dev.
