### PR TITLE
Reorder menu categories

### DIFF
--- a/src/category/controllers/populate_category.py
+++ b/src/category/controllers/populate_category.py
@@ -18,7 +18,15 @@ class PopulateCategoryController:
         category_items = {"category_name" : id, ... }
         """
         category_items = {}
-        for json_menu in json_event["menu"]:
+
+        category_order = ["Chef's Table", "Chef's Table - Sides", "Grill", "Wok", 
+         "Wok/Asian Station", "Iron Grill", "Mexican Station", "Global",
+         "Halal", "Kosher Station", "Flat Top Grill"]
+        
+        def sort_menu(menu):
+            return category_order.index(menu["category"].strip()) if menu["category"].strip() in category_order else 1000
+
+        for json_menu in sorted(json_event["menu"], key=sort_menu):
             data = {"event": event, "category": json_menu["category"]}
             category = CategorySerializer(data=data)
 

--- a/src/category/controllers/populate_category.py
+++ b/src/category/controllers/populate_category.py
@@ -24,8 +24,10 @@ class PopulateCategoryController:
          "Halal", "Kosher Station", "Flat Top Grill"]
         
         def sort_menu(menu):
-            order = category_order.find(menu["category"].strip())
-            return order if order != -1 else len(category_order)
+            try:
+                return category_order.index(menu["category"].strip())
+            except ValueError:
+                return len(category_order)
 
         for json_menu in sorted(json_event["menu"], key=sort_menu):
             data = {"event": event, "category": json_menu["category"]}

--- a/src/category/controllers/populate_category.py
+++ b/src/category/controllers/populate_category.py
@@ -24,7 +24,8 @@ class PopulateCategoryController:
          "Halal", "Kosher Station", "Flat Top Grill"]
         
         def sort_menu(menu):
-            return category_order.index(menu["category"].strip()) if menu["category"].strip() in category_order else len(category_order)
+            order = category_order.find(menu["category"].strip())
+            return order if order != -1 else len(category_order)
 
         for json_menu in sorted(json_event["menu"], key=sort_menu):
             data = {"event": event, "category": json_menu["category"]}

--- a/src/category/controllers/populate_category.py
+++ b/src/category/controllers/populate_category.py
@@ -24,7 +24,7 @@ class PopulateCategoryController:
          "Halal", "Kosher Station", "Flat Top Grill"]
         
         def sort_menu(menu):
-            return category_order.index(menu["category"].strip()) if menu["category"].strip() in category_order else 1000
+            return category_order.index(menu["category"].strip()) if menu["category"].strip() in category_order else len(category_order)
 
         for json_menu in sorted(json_event["menu"], key=sort_menu):
             data = {"event": event, "category": json_menu["category"]}


### PR DESCRIPTION
## Overview

Added an order and priority to certain important categories for each eatery.

## Changes Made

Sorted the categories based on the following order: ["Chef's Table", "Chef's Table - Sides", "Grill", "Wok", "Wok/Asian Station", "Iron Grill", "Mexican Station", "Global", "Halal", "Kosher Station", "Flat Top Grill"]. All other categories stay in order given by CDN and come after these prioritized categories.

## Test Coverage

Tested locally.
