### PR TITLE
Fix Item Crash

### DIFF
--- a/src/eatery_blue_backend/settings.py
+++ b/src/eatery_blue_backend/settings.py
@@ -108,6 +108,7 @@ DATABASES = {
         "PASSWORD": os.getenv("POSTGRES_PASSWORD"),
         "HOST": os.getenv("POSTGRES_HOST"),
         "PORT": os.getenv("POSTGRES_PORT"),
+        'CONN_MAX_AGE': 0,
     }
 }
 

--- a/src/item/controllers/populate_item.py
+++ b/src/item/controllers/populate_item.py
@@ -19,14 +19,16 @@ class PopulateItemController:
             allergens = json_item.get("allergens", [])
             
             data = {"category": category_id, "name": json_item["item"], "dietary_preferences": dietary_preferences, "allergens": allergens}
-            item = ItemSerializer(data=data)
-            if item.is_valid():
-                try:
+            try:
+                item = ItemSerializer(data=data)
+                if item.is_valid():
                     item.save()
-                except Exception as e:
-                    print(f"Error saving item {json_item['item']}. Skipping...")
-            else:
-                print(item.errors)
+                else:
+                    print(item.errors)
+            except Exception as e:
+                print(f"Error saving item: {e}")
+                print(f"Data: {data}")
+                
 
     def generate_dining_hall_items(self, menu, json_event, json_eatery):
         json_menus = json_event["menu"]

--- a/src/item/controllers/populate_item.py
+++ b/src/item/controllers/populate_item.py
@@ -21,7 +21,10 @@ class PopulateItemController:
             data = {"category": category_id, "name": json_item["item"], "dietary_preferences": dietary_preferences, "allergens": allergens}
             item = ItemSerializer(data=data)
             if item.is_valid():
-                item.save()
+                try:
+                    item.save()
+                except Exception as e:
+                    print(f"Error saving item {json_item['item']}. Skipping...")
             else:
                 print(item.errors)
 

--- a/src/item/serializers.py
+++ b/src/item/serializers.py
@@ -17,13 +17,21 @@ class ItemSerializer(serializers.ModelSerializer):
         allergens = validated_data.pop('allergens', [])
         item, _ = Item.objects.get_or_create(**validated_data)
 
+        dietary_prefs_objects = []
         for pref_name in dietary_prefs:
             pref, _ = DietaryPreference.objects.get_or_create(name=pref_name)
-            item.dietary_preferences.add(pref)
+            dietary_prefs_objects.append(pref)
+        
+        if dietary_prefs_objects:
+            item.dietary_preferences.add(*dietary_prefs_objects)
 
+        allergens_objects = []
         for allergen_name in allergens:
             allergen, _ = Allergen.objects.get_or_create(name=allergen_name)
-            item.allergens.add(allergen)
+            allergens_objects.append(allergen)
+
+        if allergens_objects:
+            item.allergens.add(*allergens_objects)
 
         return item
 


### PR DESCRIPTION
Adding an item over 40 characters would throw an exception and crash the backend server. Added a try block to catch that error in case the form is mismatched again