### PR TITLE
ItemSerializer N+1 Query Fix

### DIFF
--- a/src/item/serializers.py
+++ b/src/item/serializers.py
@@ -10,11 +10,11 @@ class ItemSerializer(serializers.ModelSerializer):
 
     def get_dietary_preferences(self, obj):
         """Get list of dietary preference names"""
-        return list(obj.dietary_preferences.values_list('name', flat=True))
+        return [pref.name for pref in obj.dietary_preferences.all()]
     
     def get_allergens(self, obj):
         """Get list of allergen names"""
-        return list(obj.allergens.values_list('name', flat=True))
+        return [allergen.name for allergen in obj.allergens.all()]
 
     def create(self, validated_data):
         dietary_prefs = validated_data.pop('dietary_preferences', [])


### PR DESCRIPTION
## Overview
Switched ItemSerializer to use .all() instead of .values_list(). 
.values_list() made a new query to get dietery restrictions from each item, even though we used prefetch in the view. .all() checks the prefetched values first, preventing the n+1 problem.

## Changes Made
Switched ItemSerializer to use .all() instead of .values_list().


## Test Coverage
Locally logged number of requests when hitting key endpoints: '/eatery/', '/eatery/1/', '/event/', '/category/', '/item/'. 
Before, was >9000, now 3-5
Also verified responses were the same across tests.