### PR TITLE
Deserialize allergen info and dietary restrictions & remove unnecessary references

### DIFF
--- a/src/category/views.py
+++ b/src/category/views.py
@@ -9,7 +9,4 @@ class CategoryViewSet(viewsets.ReadOnlyModelViewSet):
     
     def get_queryset(self):
         # prefetch items and their related fields
-        return Category.objects.select_related('event__eatery').prefetch_related(
-            'items__dietary_preferences',
-            'items__allergens'
-        ).all()
+        return Category.objects.select_related('event__eatery').all()

--- a/src/eatery/views.py
+++ b/src/eatery/views.py
@@ -32,20 +32,6 @@ class EateryViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = EaterySerializer
     permission_classes = [EateryPermission]
 
-    @profile
-    def get_queryset(self):
-        """
-        Override to add prefetch_related for optimization
-        """
-        queryset = super().get_queryset()
-
-        if self.action in ["list", "retrieve"]:
-            return queryset.prefetch_related(
-                "events__menu__items__dietary_preferences",
-                "events__menu__items__allergens",
-            )
-
-        return queryset
 
     @profile
     @method_decorator(
@@ -158,8 +144,6 @@ class GetEateriesByDay(APIView):
             "events",
             queryset=Event.objects.filter(
                 start__gte=start_unix, start__lt=end_unix
-            ).prefetch_related(
-                "menu__items__dietary_preferences", "menu__items__allergens"
             ),
             to_attr="filtered_events",
         )

--- a/src/event/views.py
+++ b/src/event/views.py
@@ -9,7 +9,4 @@ class EventViewSet(viewsets.ReadOnlyModelViewSet):
     
     def get_queryset(self):
         # prefetch related menu categories and items
-        return Event.objects.select_related('eatery').prefetch_related(
-            'menu__items__dietary_preferences',
-            'menu__items__allergens'
-        ).all()
+        return Event.objects.select_related('eatery').all()

--- a/src/item/serializers.py
+++ b/src/item/serializers.py
@@ -5,38 +5,9 @@ from item.models import Item, DietaryPreference, Allergen
 class ItemSerializer(serializers.ModelSerializer):
     id = serializers.IntegerField(read_only=True)
     name = serializers.CharField(default="Item")
-    dietary_preferences = serializers.SerializerMethodField()
-    allergens = serializers.SerializerMethodField()
-
-    def get_dietary_preferences(self, obj):
-        """Get list of dietary preference names"""
-        return [pref.name for pref in obj.dietary_preferences.all()]
-    
-    def get_allergens(self, obj):
-        """Get list of allergen names"""
-        return [allergen.name for allergen in obj.allergens.all()]
 
     def create(self, validated_data):
-        dietary_prefs = validated_data.pop('dietary_preferences', [])
-        allergens = validated_data.pop('allergens', [])
         item, _ = Item.objects.get_or_create(**validated_data)
-
-        dietary_prefs_objects = []
-        for pref_name in dietary_prefs:
-            pref, _ = DietaryPreference.objects.get_or_create(name=pref_name)
-            dietary_prefs_objects.append(pref)
-        
-        if dietary_prefs_objects:
-            item.dietary_preferences.add(*dietary_prefs_objects)
-
-        allergens_objects = []
-        for allergen_name in allergens:
-            allergen, _ = Allergen.objects.get_or_create(name=allergen_name)
-            allergens_objects.append(allergen)
-
-        if allergens_objects:
-            item.allergens.add(*allergens_objects)
-
         return item
     
     def update(self, instance, validated_data):
@@ -47,11 +18,11 @@ class ItemSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Item
-        fields = ["id", "category", "name", "base_price", "dietary_preferences", "allergens"]
+        fields = ["id", "category", "name", "base_price"]
         read_only_fields = ["id"]
 
 
 class ItemSerializerOptimized(serializers.ModelSerializer):
     class Meta:
         model = Item
-        fields = ["id", "name", "dietary_preferences", "allergens"]
+        fields = ["id", "name"]

--- a/src/item/views.py
+++ b/src/item/views.py
@@ -10,7 +10,4 @@ class ItemViewSet(viewsets.ReadOnlyModelViewSet):
     def get_queryset(self):
         return Item.objects.select_related(
             'category__event__eatery'
-        ).prefetch_related(
-            'dietary_preferences',
-            'allergens'
         ).all()


### PR DESCRIPTION
## Overview

Got rid of unnecessary fields in the serializer and unused logic in creation of items


## Changes Made

Removed dietary_restrictions and allergens fields from serializer and any other references to dietary restrictions and allergens in the ItemSerializer class.


## Test Coverage

Tested locally
